### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+aptitude-robot (1.5.4-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 19 Sep 2021 12:44:01 -0000
+
 aptitude-robot (1.5.4-1) unstable; urgency=medium
 
   * Version 1.5.4 (minor bug + documentation fixes)

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/elmar/aptitude-robot/issues
+Bug-Submit: https://github.com/elmar/aptitude-robot/issues/new
+Repository: https://github.com/elmar/aptitude-robot.git
+Repository-Browse: https://github.com/elmar/aptitude-robot


### PR DESCRIPTION

Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/aptitude-robot/4b4b1886-ff67-48cd-9f6b-ad91b6696c7c.
